### PR TITLE
Allow all platformio frameworks

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,6 +14,6 @@
   },
   "version": "1.0.0",
   "license": "MIT",
-  "frameworks": "arduino",
+  "frameworks": "*",
   "platforms": "*"
 }


### PR DESCRIPTION
Package is already compatible with  "espidf" framework.
It probably is compatible with many more that support cpp.
Allowing all frameworks allows the library to be used by other frameworks, too.